### PR TITLE
Extract shared helpers to deduplicate parse_times and slugify

### DIFF
--- a/custom_components/medication_reminder/config_flow.py
+++ b/custom_components/medication_reminder/config_flow.py
@@ -5,36 +5,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 
 from .const import DOMAIN, ATTR_NAME, ATTR_DOSE, ATTR_TIMES
-
-
-def _slugify(name: str) -> str:
-    base = "".join(ch if ch.isalnum() else "_" for ch in name.lower())
-    return "_".join([p for p in base.split("_") if p])
-
-
-def _normalize_times(value: str) -> list[str]:
-    items = [v.strip() for v in value.split(",")]
-    out: list[str] = []
-    for t in items:
-        if not t:
-            continue
-        try:
-            hh, mm = t.split(":")
-            hhi = int(hh)
-            mmi = int(mm)
-        except Exception as err:
-            raise vol.Invalid(f"Invalid time format: {t}") from err
-        if not (0 <= hhi <= 23 and 0 <= mmi <= 59):
-            raise vol.Invalid(f"Invalid time value: {t}")
-        out.append(f"{hhi:02d}:{mmi:02d}")
-    # de-duplicate
-    seen = set()
-    unique: list[str] = []
-    for t in out:
-        if t not in seen:
-            seen.add(t)
-            unique.append(t)
-    return unique
+from .helpers import normalize_times, slugify
 
 
 class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -47,14 +18,14 @@ class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 name = user_input.get(ATTR_NAME, "").strip()
                 dose = user_input.get(ATTR_DOSE, "").strip()
                 times_raw = user_input.get(ATTR_TIMES, "").strip()
-                times = _normalize_times(times_raw)
+                times = normalize_times(times_raw)
 
                 if not name:
                     errors[ATTR_NAME] = "required"
                 elif not times:
                     errors[ATTR_TIMES] = "required"
                 else:
-                    slug = _slugify(name)
+                    slug = slugify(name)
                     await self.async_set_unique_id(f"med_{slug}")
                     self._abort_if_unique_id_configured()
                     title = name
@@ -88,7 +59,7 @@ class MedicationReminderOptionsFlow(config_entries.OptionsFlow):
             try:
                 dose = (user_input.get(ATTR_DOSE) or "").strip()
                 times_raw = (user_input.get(ATTR_TIMES) or "")
-                times = _normalize_times(times_raw)
+                times = normalize_times(times_raw)
                 snooze = int(user_input.get("snooze_minutes", 5))
                 if snooze < 1:
                     snooze = 1

--- a/custom_components/medication_reminder/helpers.py
+++ b/custom_components/medication_reminder/helpers.py
@@ -1,0 +1,55 @@
+"""Shared utility functions for Medication Reminder."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+
+def slugify(name: str) -> str:
+    """Convert a medication name to a slug suitable for entity IDs.
+
+    Replaces non-alphanumeric characters with underscores, lowercases
+    the result, and collapses consecutive underscores.
+    """
+    base = "".join(ch if ch.isalnum() else "_" for ch in name.lower())
+    return "_".join([p for p in base.split("_") if p])
+
+
+def parse_times(value: str | list[str]) -> list[str]:
+    """Parse and normalize time strings into a deduplicated list of ``HH:MM`` values.
+
+    *value* may be a comma-separated string (``"08:00, 20:00"``) or
+    a list of individual time strings.  Each token is validated and
+    normalized to zero-padded 24-hour format.  Duplicates are removed
+    while preserving order.
+
+    Raises ``vol.Invalid`` on malformed or out-of-range times.
+    """
+    if isinstance(value, list):
+        items = value
+    else:
+        items = [v.strip() for v in value.split(",")]
+    out: list[str] = []
+    for t in items:
+        if not t:
+            continue
+        try:
+            hh, mm = t.split(":")
+            hhi = int(hh)
+            mmi = int(mm)
+        except Exception as err:
+            raise vol.Invalid(f"Invalid time format: {t}") from err
+        if not (0 <= hhi <= 23 and 0 <= mmi <= 59):
+            raise vol.Invalid(f"Invalid time value: {t}")
+        out.append(f"{hhi:02d}:{mmi:02d}")
+    # remove duplicates, keep order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for t in out:
+        if t not in seen:
+            seen.add(t)
+            unique.append(t)
+    return unique
+
+
+# Alias kept for backward compatibility with config_flow naming convention.
+normalize_times = parse_times

--- a/custom_components/medication_reminder/sensor.py
+++ b/custom_components/medication_reminder/sensor.py
@@ -6,8 +6,6 @@ from datetime import timedelta
 from typing import Callable, List, Optional
 import re
 
-import voluptuous as vol
-
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -28,41 +26,8 @@ from .const import (
     STATE_SNOOZED,
     SIGNAL_HISTORY_UPDATED,
 )
+from .helpers import parse_times, slugify
 from .history import HistoryManager
-
-
-def _slugify(name: str) -> str:
-    base = "".join(ch if ch.isalnum() else "_" for ch in name.lower())
-    return "_".join([p for p in base.split("_") if p])
-
-
-def _parse_times(value: str | list[str]) -> list[str]:
-    """Parse HH:MM or list of HH:MM values; return normalized list."""
-    if isinstance(value, list):
-        items = value
-    else:
-        items = [v.strip() for v in value.split(",")]
-    out: list[str] = []
-    for t in items:
-        if not t:
-            continue
-        try:
-            hh, mm = t.split(":")
-            hhi = int(hh)
-            mmi = int(mm)
-        except Exception as err:
-            raise vol.Invalid(f"Invalid time format: {t}") from err
-        if not (0 <= hhi <= 23 and 0 <= mmi <= 59):
-            raise vol.Invalid(f"Invalid time value: {t}")
-        out.append(f"{hhi:02d}:{mmi:02d}")
-    # remove duplicates, keep order
-    seen = set()
-    unique: list[str] = []
-    for t in out:
-        if t not in seen:
-            seen.add(t)
-            unique.append(t)
-    return unique
 
 
 async def async_setup_entry(
@@ -71,7 +36,7 @@ async def async_setup_entry(
     name: str = entry.data.get(ATTR_NAME) or entry.title or "Medication"
     dose: str = (entry.options.get(ATTR_DOSE) or entry.data.get(ATTR_DOSE) or "").strip()
     times_raw = entry.options.get(ATTR_TIMES) or entry.data.get(ATTR_TIMES) or []
-    times = _parse_times(times_raw) if isinstance(times_raw, str) else list(times_raw)
+    times = parse_times(times_raw) if isinstance(times_raw, str) else list(times_raw)
 
     snooze_minutes = int(entry.options.get("snooze_minutes", DEFAULT_SNOOZE_MINUTES))
     notify_services_raw = (entry.options.get("notify_services") or "").strip()
@@ -121,7 +86,7 @@ async def async_setup_entry(
         times=times,
         history=history,
         source_entity_id=None,  # Will be filled after med_entity has entity_id
-        slug=_slugify(name),
+        slug=slugify(name),
     )
 
     stats_entity = MedicationStatsSensor(
@@ -130,7 +95,7 @@ async def async_setup_entry(
         times=times,
         history=history,
         source_entity_id=None,  # Set after med_entity created
-        slug=_slugify(name),
+        slug=slugify(name),
     )
 
     # Link adherence sensor to the medication entity
@@ -142,7 +107,7 @@ async def async_setup_entry(
         new_dose = (updated_entry.options.get(ATTR_DOSE) or updated_entry.data.get(ATTR_DOSE) or "").strip()
         new_times_raw = updated_entry.options.get(ATTR_TIMES) or updated_entry.data.get(ATTR_TIMES) or []
         new_times = (
-            _parse_times(new_times_raw) if isinstance(new_times_raw, str) else list(new_times_raw)
+            parse_times(new_times_raw) if isinstance(new_times_raw, str) else list(new_times_raw)
         )
         new_snooze = int(updated_entry.options.get("snooze_minutes", DEFAULT_SNOOZE_MINUTES))
         new_notify_raw = (updated_entry.options.get("notify_services") or "").strip()
@@ -199,7 +164,7 @@ class MedicationSensor(SensorEntity):
         self._init_refill_total = max(0, int(refill_total))
         self._entry_id = entry_id
 
-        slug = _slugify(name)
+        slug = slugify(name)
         self._attr_name = name
         self._attr_unique_id = f"med_{slug}"
         # Stable entity_id using HA helper; remains sensor.medication_<slug> when free


### PR DESCRIPTION
## Summary
- Created `custom_components/medication_reminder/helpers.py` with shared `slugify()` and `parse_times()` functions (plus `normalize_times` alias)
- Removed duplicate `_slugify` and `_parse_times`/`_normalize_times` from `sensor.py` and `config_flow.py`, replacing with imports from the new shared module
- Added docstrings and type hints to the extracted functions; removed unused `voluptuous` import from `sensor.py`

## Test plan
- [x] All three modified files pass `ast.parse()` syntax validation
- [ ] Manual HA integration testing (requires running instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)