### PR TITLE
Add services, strings, and translations for v0.2.0 drug interactions

### DIFF
--- a/custom_components/medication_reminder/const.py
+++ b/custom_components/medication_reminder/const.py
@@ -28,3 +28,17 @@ STATE_SNOOZED = "Snoozed"
 HISTORY_STORE_KEY = f"{DOMAIN}_history"
 HISTORY_STORE_VERSION = 1
 SIGNAL_HISTORY_UPDATED = f"{DOMAIN}_history_updated"
+
+# API endpoints
+RXTERMS_API_URL = "https://clinicaltables.nlm.nih.gov/api/rxterms/v3/search"
+OPENFDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
+
+# Cache
+INTERACTION_CACHE_TTL = 86400  # 24 hours in seconds
+
+# Events
+EVENT_INTERACTION_WARNING = f"{DOMAIN}_interaction_warning"
+
+# Drug interaction attributes
+ATTR_RXCUI = "rxcui"
+ATTR_DRUG_INFO = "drug_info"

--- a/custom_components/medication_reminder/services.yaml
+++ b/custom_components/medication_reminder/services.yaml
@@ -89,3 +89,9 @@ refill_acknowledge:
     entity_id:
       description: Medication entity
       example: sensor.medication_aspirin
+
+check_interactions:
+  description: Check for drug interactions between configured medications
+  target:
+    entity:
+      domain: sensor

--- a/custom_components/medication_reminder/strings.json
+++ b/custom_components/medication_reminder/strings.json
@@ -4,11 +4,19 @@
     "step": {
       "user": {
         "title": "Add Medication",
-        "description": "Enter the medication details.",
+        "description": "Search for a medication or enter the name manually.",
         "data": {
-          "name": "Name",
-          "dose": "Dose",
-          "times": "Times (HH:MM, comma-separated)"
+          "name": "Medication Name",
+          "dose": "Dose (e.g., 500mg)",
+          "times": "Reminder Times (HH:MM, comma-separated)",
+          "search_query": "Search medications (FDA database)"
+        }
+      },
+      "select_medication": {
+        "title": "Select Medication",
+        "description": "Choose from the search results or go back to enter manually.",
+        "data": {
+          "selected_medication": "Select a medication"
         }
       }
     },

--- a/custom_components/medication_reminder/translations/en.json
+++ b/custom_components/medication_reminder/translations/en.json
@@ -3,11 +3,19 @@
     "step": {
       "user": {
         "title": "Add Medication",
-        "description": "Enter the medication details.",
+        "description": "Search for a medication or enter the name manually.",
         "data": {
-          "name": "Name",
-          "dose": "Dose",
-          "times": "Times (HH:MM, comma-separated)"
+          "name": "Medication Name",
+          "dose": "Dose (e.g., 500mg)",
+          "times": "Reminder Times (HH:MM, comma-separated)",
+          "search_query": "Search medications (FDA database)"
+        }
+      },
+      "select_medication": {
+        "title": "Select Medication",
+        "description": "Choose from the search results or go back to enter manually.",
+        "data": {
+          "selected_medication": "Select a medication"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Added `check_interactions` service definition to `services.yaml`
- Added API endpoint constants (RxTerms, OpenFDA), cache TTL, event name, and drug interaction attribute keys to `const.py`
- Updated `strings.json` and `translations/en.json` with new config flow strings for medication search and selection steps

## Test plan
- [x] Python syntax validation passes (`ast.parse` on const.py)
- [x] JSON syntax validation passes (strings.json, translations/en.json)
- [x] YAML syntax validation passes (services.yaml)
- [x] All existing strings and translations preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)