### PR TITLE
Add FDA/NIH API proxy for medication autocomplete

### DIFF
--- a/custom_components/medication_reminder/api.py
+++ b/custom_components/medication_reminder/api.py
@@ -1,0 +1,119 @@
+"""FDA/NIH API helpers for medication lookup."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+RXTERMS_URL = "https://clinicaltables.nlm.nih.gov/api/rxterms/v3/search"
+OPENFDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+
+async def search_medications(
+    session: aiohttp.ClientSession,
+    query: str,
+    max_results: int = 10,
+) -> list[dict[str, Any]]:
+    """Search RxTerms for medications matching *query*.
+
+    Returns a list of dicts with keys: name, strengths_and_forms, rxcui.
+    Returns an empty list on any error.
+    """
+    query = (query or "").strip()
+    if not query:
+        return []
+
+    params = {
+        "terms": query,
+        "ef": "STRENGTHS_AND_FORMS,RXCUIS",
+        "maxList": str(max_results),
+    }
+
+    try:
+        async with session.get(
+            RXTERMS_URL, params=params, timeout=REQUEST_TIMEOUT
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json(content_type=None)
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as err:
+        _LOGGER.warning("RxTerms search failed for %r: %s", query, err)
+        return []
+
+    # Response format: [totalCount, codeArray, {extraFields}, displayNames]
+    try:
+        _count, _codes, extra_fields, display_names = data
+    except (ValueError, TypeError):
+        _LOGGER.warning("Unexpected RxTerms response format: %s", data)
+        return []
+
+    strengths_list = extra_fields.get("STRENGTHS_AND_FORMS", [])
+    rxcuis_list = extra_fields.get("RXCUIS", [])
+
+    results: list[dict[str, Any]] = []
+    for idx, name in enumerate(display_names):
+        strengths = strengths_list[idx] if idx < len(strengths_list) else []
+        rxcuis = rxcuis_list[idx] if idx < len(rxcuis_list) else []
+        results.append(
+            {
+                "name": name,
+                "strengths_and_forms": strengths if isinstance(strengths, list) else [],
+                "rxcui": rxcuis[0] if rxcuis else "",
+            }
+        )
+
+    return results
+
+
+async def get_drug_details(
+    session: aiohttp.ClientSession,
+    rxcui: str,
+) -> dict[str, str] | None:
+    """Fetch drug label details from OpenFDA for a given RxCUI.
+
+    Returns a dict with dosage_and_administration, drug_interactions,
+    warnings, and indications_and_usage (all strings).
+    Returns None on any error or if no results are found.
+    """
+    if not rxcui:
+        return None
+
+    params = {
+        "search": f'openfda.rxcui:"{rxcui}"',
+        "limit": "1",
+    }
+
+    try:
+        async with session.get(
+            OPENFDA_LABEL_URL, params=params, timeout=REQUEST_TIMEOUT
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json(content_type=None)
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as err:
+        _LOGGER.warning("OpenFDA lookup failed for rxcui=%s: %s", rxcui, err)
+        return None
+
+    try:
+        result = data["results"][0]
+    except (KeyError, IndexError, TypeError):
+        _LOGGER.debug("No OpenFDA results for rxcui=%s", rxcui)
+        return None
+
+    def _first_str(field: str) -> str:
+        val = result.get(field)
+        if isinstance(val, list) and val:
+            return str(val[0])
+        if isinstance(val, str):
+            return val
+        return ""
+
+    return {
+        "dosage_and_administration": _first_str("dosage_and_administration"),
+        "drug_interactions": _first_str("drug_interactions"),
+        "warnings": _first_str("warnings"),
+        "indications_and_usage": _first_str("indications_and_usage"),
+    }

--- a/custom_components/medication_reminder/config_flow.py
+++ b/custom_components/medication_reminder/config_flow.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import get_drug_details, search_medications
 from .const import DOMAIN, ATTR_NAME, ATTR_DOSE, ATTR_TIMES
+
+CONF_SEARCH_QUERY = "search_query"
+CONF_ENTRY_MODE = "entry_mode"
+CONF_SELECTED_MED = "selected_medication"
+
+MODE_SEARCH = "search"
+MODE_MANUAL = "manual"
 
 
 def _slugify(name: str) -> str:
@@ -28,7 +37,7 @@ def _normalize_times(value: str) -> list[str]:
             raise vol.Invalid(f"Invalid time value: {t}")
         out.append(f"{hhi:02d}:{mmi:02d}")
     # de-duplicate
-    seen = set()
+    seen: set[str] = set()
     unique: list[str] = []
     for t in out:
         if t not in seen:
@@ -40,28 +49,139 @@ def _normalize_times(value: str) -> list[str]:
 class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        errors = {}
-        if user_input is not None:
-            try:
-                name = user_input.get(ATTR_NAME, "").strip()
-                dose = user_input.get(ATTR_DOSE, "").strip()
-                times_raw = user_input.get(ATTR_TIMES, "").strip()
-                times = _normalize_times(times_raw)
+    def __init__(self) -> None:
+        """Initialise flow state."""
+        super().__init__()
+        self._search_results: list[dict] = []
+        self._selected_name: str = ""
+        self._selected_dose: str = ""
+        self._selected_rxcui: str = ""
+        self._drug_info: dict = {}
 
-                if not name:
-                    errors[ATTR_NAME] = "required"
-                elif not times:
-                    errors[ATTR_TIMES] = "required"
+    # ------------------------------------------------------------------
+    # Step 1: choose search vs manual entry
+    # ------------------------------------------------------------------
+    async def async_step_user(self, user_input=None):
+        """First step -- search for a medication or enter manually."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            mode = user_input.get(CONF_ENTRY_MODE, MODE_SEARCH)
+            if mode == MODE_MANUAL:
+                return await self.async_step_manual()
+
+            query = (user_input.get(CONF_SEARCH_QUERY) or "").strip()
+            if not query:
+                errors[CONF_SEARCH_QUERY] = "required"
+            else:
+                session = async_get_clientsession(self.hass)
+                results = await search_medications(session, query)
+                if results:
+                    self._search_results = results
+                    return await self.async_step_select_medication()
+                # API returned nothing -- let user know and stay on form
+                errors["base"] = "no_results"
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_ENTRY_MODE, default=MODE_SEARCH): vol.In(
+                    {MODE_SEARCH: "Search FDA database", MODE_MANUAL: "Enter manually"}
+                ),
+                vol.Optional(CONF_SEARCH_QUERY, default=""): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="user", data_schema=schema, errors=errors
+        )
+
+    # ------------------------------------------------------------------
+    # Step 2: select from search results
+    # ------------------------------------------------------------------
+    async def async_step_select_medication(self, user_input=None):
+        """Let the user pick a medication from the search results."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            idx_str = user_input.get(CONF_SELECTED_MED)
+            try:
+                idx = int(idx_str)
+                med = self._search_results[idx]
+            except (TypeError, ValueError, IndexError):
+                errors[CONF_SELECTED_MED] = "invalid_selection"
+            else:
+                self._selected_name = med["name"]
+                self._selected_rxcui = med.get("rxcui", "")
+
+                # Pick the first strength/form as default dose if available
+                forms = med.get("strengths_and_forms") or []
+                self._selected_dose = forms[0] if forms else ""
+
+                # Fetch detailed drug info in the background
+                if self._selected_rxcui:
+                    session = async_get_clientsession(self.hass)
+                    details = await get_drug_details(session, self._selected_rxcui)
+                    self._drug_info = details or {}
                 else:
-                    slug = _slugify(name)
-                    await self.async_set_unique_id(f"med_{slug}")
-                    self._abort_if_unique_id_configured()
-                    title = name
-                    data = {ATTR_NAME: name, ATTR_DOSE: dose, ATTR_TIMES: times}
-                    return self.async_create_entry(title=title, data=data)
-            except vol.Invalid as err:
-                errors["base"] = "invalid_times"
+                    self._drug_info = {}
+
+                return await self.async_step_confirm()
+
+        # Build selector options from search results
+        options = {
+            str(i): med["name"] for i, med in enumerate(self._search_results)
+        }
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_SELECTED_MED): vol.In(options),
+            }
+        )
+        return self.async_show_form(
+            step_id="select_medication", data_schema=schema, errors=errors
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3a: confirm / edit details from API selection
+    # ------------------------------------------------------------------
+    async def async_step_confirm(self, user_input=None):
+        """Show pre-populated fields for the selected medication."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            result = self._create_entry_from_input(user_input, errors)
+            if result is not None:
+                return result
+            # errors dict was populated -- fall through to re-show form
+
+        schema = vol.Schema(
+            {
+                vol.Required(ATTR_NAME, default=self._selected_name): str,
+                vol.Optional(ATTR_DOSE, default=self._selected_dose): str,
+                vol.Required(
+                    ATTR_TIMES,
+                    description={"suggested_value": "08:00, 20:00"},
+                ): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="confirm", data_schema=schema, errors=errors
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3b: manual entry (fallback)
+    # ------------------------------------------------------------------
+    async def async_step_manual(self, user_input=None):
+        """Manual medication entry -- same as old async_step_user."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Reset API-sourced fields
+            self._selected_rxcui = ""
+            self._drug_info = {}
+            result = self._create_entry_from_input(user_input, errors)
+            if result is not None:
+                return result
+            # errors dict was populated -- fall through to re-show form
 
         schema = vol.Schema(
             {
@@ -69,13 +189,47 @@ class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(ATTR_DOSE, default=""): str,
                 vol.Required(
                     ATTR_TIMES,
-                    description={
-                        "suggested_value": "08:00, 20:00",
-                    },
+                    description={"suggested_value": "08:00, 20:00"},
                 ): str,
             }
         )
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+        return self.async_show_form(
+            step_id="manual", data_schema=schema, errors=errors
+        )
+
+    # ------------------------------------------------------------------
+    # Shared helper to create the config entry
+    # ------------------------------------------------------------------
+    def _create_entry_from_input(self, user_input, errors):
+        """Validate common fields and create the config entry."""
+        try:
+            name = (user_input.get(ATTR_NAME) or "").strip()
+            dose = (user_input.get(ATTR_DOSE) or "").strip()
+            times_raw = (user_input.get(ATTR_TIMES) or "").strip()
+            times = _normalize_times(times_raw)
+
+            if not name:
+                errors[ATTR_NAME] = "required"
+            elif not times:
+                errors[ATTR_TIMES] = "required"
+            else:
+                slug = _slugify(name)
+                self.async_set_unique_id(f"med_{slug}")
+                self._abort_if_unique_id_configured()
+                data = {
+                    ATTR_NAME: name,
+                    ATTR_DOSE: dose,
+                    ATTR_TIMES: times,
+                    "rxcui": self._selected_rxcui,
+                    "drug_info": self._drug_info,
+                }
+                return self.async_create_entry(title=name, data=data)
+        except vol.Invalid:
+            errors["base"] = "invalid_times"
+
+        # If we reach here there were validation errors.  Return None so the
+        # caller re-shows its own form.
+        return None
 
 
 class MedicationReminderOptionsFlow(config_entries.OptionsFlow):

--- a/custom_components/medication_reminder/manifest.json
+++ b/custom_components/medication_reminder/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "medication_reminder",
   "name": "Medication Reminder",
-  "version": "0.10.0",
+  "version": "0.2.0-beta",
   "documentation": "https://github.com/ericrosenberg1/ha-medication-manager",
   "requirements": [],
   "dependencies": [],
   "codeowners": ["@ericrosenberg1"],
-  "iot_class": "local_push",
+  "iot_class": "cloud_polling",
   "config_flow": true,
   "issue_tracker": "https://github.com/ericrosenberg1/ha-medication-manager/issues"
 }

--- a/custom_components/medication_reminder/strings.json
+++ b/custom_components/medication_reminder/strings.json
@@ -4,6 +4,30 @@
     "step": {
       "user": {
         "title": "Add Medication",
+        "description": "Search the FDA database for your medication, or choose manual entry.",
+        "data": {
+          "entry_mode": "Entry mode",
+          "search_query": "Medication name to search"
+        }
+      },
+      "select_medication": {
+        "title": "Select Medication",
+        "description": "Choose your medication from the search results.",
+        "data": {
+          "selected_medication": "Medication"
+        }
+      },
+      "confirm": {
+        "title": "Confirm Medication Details",
+        "description": "Review and complete the medication details.",
+        "data": {
+          "name": "Name",
+          "dose": "Dose",
+          "times": "Times (HH:MM, comma-separated)"
+        }
+      },
+      "manual": {
+        "title": "Add Medication Manually",
         "description": "Enter the medication details.",
         "data": {
           "name": "Name",
@@ -14,7 +38,9 @@
     },
     "error": {
       "invalid_times": "Invalid time format. Use HH:MM,HH:MM",
-      "required": "This field is required"
+      "required": "This field is required",
+      "no_results": "No medications found. Try a different search or use manual entry.",
+      "invalid_selection": "Invalid selection. Please try again."
     }
   },
   "options": {

--- a/custom_components/medication_reminder/translations/en.json
+++ b/custom_components/medication_reminder/translations/en.json
@@ -3,6 +3,30 @@
     "step": {
       "user": {
         "title": "Add Medication",
+        "description": "Search the FDA database for your medication, or choose manual entry.",
+        "data": {
+          "entry_mode": "Entry mode",
+          "search_query": "Medication name to search"
+        }
+      },
+      "select_medication": {
+        "title": "Select Medication",
+        "description": "Choose your medication from the search results.",
+        "data": {
+          "selected_medication": "Medication"
+        }
+      },
+      "confirm": {
+        "title": "Confirm Medication Details",
+        "description": "Review and complete the medication details.",
+        "data": {
+          "name": "Name",
+          "dose": "Dose",
+          "times": "Times (HH:MM, comma-separated)"
+        }
+      },
+      "manual": {
+        "title": "Add Medication Manually",
         "description": "Enter the medication details.",
         "data": {
           "name": "Name",
@@ -13,7 +37,9 @@
     },
     "error": {
       "invalid_times": "Invalid time format. Use HH:MM,HH:MM",
-      "required": "This field is required"
+      "required": "This field is required",
+      "no_results": "No medications found. Try a different search or use manual entry.",
+      "invalid_selection": "Invalid selection. Please try again."
     }
   },
   "options": {


### PR DESCRIPTION
## Summary
- New `api.py` with async helpers: `search_medications()` queries RxTerms API, `get_drug_details()` queries OpenFDA for drug label info (dosage, interactions, warnings)
- Reworked config flow into multi-step wizard: search FDA database -> select from results -> confirm/edit details, with manual entry fallback
- Stores `rxcui` and `drug_info` in config entry data for downstream interaction checking
- All API calls have 10s timeouts and graceful error handling; config flow remains fully functional if APIs are unreachable

## Test plan
- [ ] Syntax validation passes for all modified Python files
- [ ] JSON validation passes for strings.json, en.json, manifest.json
- [ ] Manual entry path still works when user selects "Enter manually"
- [ ] Search path degrades gracefully when API is unreachable (shows "no results" error)
- [ ] Integration loads in Home Assistant with new config flow steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)