### PR TITLE
[ai-fix] Fix options flow config entry handling

### DIFF
--- a/custom_components/medication_reminder/config_flow.py
+++ b/custom_components/medication_reminder/config_flow.py
@@ -19,7 +19,7 @@ class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
-        return MedicationReminderOptionsFlow(config_entry)
+        return MedicationReminderOptionsFlow()
 
     async def async_step_user(self, user_input=None):
         """Step 1: Enter medication name, dose, and times.
@@ -90,9 +90,6 @@ class MedicationReminderConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class MedicationReminderOptionsFlow(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         errors = {}
         if user_input is not None:


### PR DESCRIPTION
## Summary
- return `MedicationReminderOptionsFlow()` without passing a config entry
- remove the custom options-flow initializer that assigned to Home Assistant's read-only `config_entry` property

Fixes #10.

## Tests
- `find . -name "*.py" -print0 | xargs -0 python3 -m py_compile`
- `uv run --with homeassistant --with voluptuous python - <<'PY' ...` (smoke-tested `async_get_options_flow`)

Also tried `uv run --with homeassistant --with pytest --with pytest-asyncio --with pytest-homeassistant-custom-component python -m pytest tests/ -v --tb=short`; it ran but existing sensor tests fail under current Home Assistant/Python 3.14 due lingering timers and read-only `ServiceRegistry.async_call` patching, unrelated to this config-flow change.

AI assistance was used under my direction.